### PR TITLE
bugfix: Added encoding to fs.readFileSync() call in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A minimal example to read this file with `enojs`:
 const eno = require('enojs');
 const fs = require('fs');
 
-const input = fs.readFileSync('intro.eno');
+const input = fs.readFileSync('intro.eno', 'utf-8');
 
 const document = eno.parse(input);
 


### PR DESCRIPTION
Fix for https://github.com/eno-lang/enojs/issues/1.